### PR TITLE
Upgrade vagrant and ldap docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_cache:
   - find $HOME/.sbt -name "*.lock" -delete
 
 before_script:
-  - curl -L https://releases.hashicorp.com/vagrant/1.8.5/vagrant_1.8.5_x86_64.deb > vagrant.deb
+  - curl -L https://releases.hashicorp.com/vagrant/1.8.6/vagrant_1.8.6_x86_64.deb > vagrant.deb
   - sudo dpkg --force-confnew -i vagrant.deb
   - vagrant up --provider=docker
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,9 +3,9 @@
 
 Vagrant.configure(2) do |config|
     config.vm.provider 'docker' do |d|
-    d.image = 'osixia/openldap:1.1.4'
-    d.ports = %w(8389:389 8636:636)
-    d.name = 'ldap'
-    d.remains_running = true
-  end
+        d.image = 'osixia/openldap:1.1.6'
+        d.ports = %w(8389:389 8636:636)
+        d.name = 'ldap'
+        d.remains_running = true
+    end
 end


### PR DESCRIPTION
Vagrant used in Travis was used in 1.8.6 and osixia/openldap was bumped to 1.1.6
